### PR TITLE
docs: update to simplified threads spec

### DIFF
--- a/3IPs/3ip-2.md
+++ b/3IPs/3ip-2.md
@@ -9,96 +9,82 @@ created: 2018-11-20
 
 # Threads: A p2p communication protocol
 
-This is the first draft of threads. This spec is likely to change.
+This is the first version of threads. This spec is likely to change.
 
 # Overview
 
-Threads is a feature that enables one or multiple users to post messages in a sequence. This enables users to communicate asynchronously in many forms. For example it could be used for comments, chats, status updates, etc. Threads uses the orbitdb feedstore to create a log of messages that is eventually consistent. They can be public or private/encrypted. Each thread is initially only owned by the creator, but more users can be added as the thread evolves.
+Threads is a feature that enables multiple users to post messages in a sequence. This allows users to communicate asynchronously in many forms. For example it could be used for comments, chats, status updates, etc. The first version of threads uses the [orbitdb logstore](https://github.com/orbitdb/orbit-db/blob/master/API.md#orbitdblognameaddress) to create a log of messages that is eventually consistent.
 
 ## Access control
 
-Right now orbitdb doen't support adding and removing users to a given DB. However if we are fine with the constraint that users can only be added to the thread and not removed we can do the following. For a new thread we create a random seed `R`. From `R` we derive a signing key `k` and a symmetric encryption key `s`. The signing key `k` is given write permissions in the orbitdb feedstore. Each user has a public encryption key `E_<user>` associated with their 3box. If *Alice*  creates the thread, she encrypts `R` to her key `E_alice` and adds this encrypted blob as an entry in the thread. Now when *Alice* want's to grant access to *Bob* she simply encrypts `R` to `E_bob` and adds this encrypted blob as an entry in the thread. *Bob* can now see this encrypted entry and decrypt it to recover `k` and `s` which can be used to post in the thread.
+This first version of threads will allow anyone to post, without any ability to remove posts. This is achieved by using `write: ['*']` when creating the store in orbitdb.
 
-OrbitDB is [working on adding](https://github.com/orbitdb/orbit-db/pull/495) support for access controllers. When they are released we can use them for write access to threads. There is not really any benefit in changing to this until they also add the ability to remove users.
+OrbitDB is [working on adding](https://github.com/orbitdb/orbit-db/pull/495) support for access controllers. When they are released we can use them for write access to threads, as well as moderation, and potentially other features as well.
 
-## Encryption
-
-We simply use `s` to symmetrically encrypt the entries in the thread if it's a private thread.
-
-## Thread subscriptions
-
-Users can subscribe to threads. This means that they will remember the thread next time they go online, and they can ask the network for updates. When a user subscribes to a thread it simply adds the thread-id and name to the rootStore of the users 3Box. When the user unsubscribes the thread entry is removed from the rootStore.
-
-## Threads in spaces?
-
-Is this something we want to enable? Maybe as a second iteration, it adds a lot of complexity.
+## Thread creation
+Threads are created inside of [Spaces](./3ip-1.md). A thread has a `name` which could be any string. For example the name could be the address of a contract if you want to create a thread for commenting on that contract. This essentially means that two different spaces could have their own threads with the same name. When a thread is created it gets the name `3box.thread.<space-name>.<thread-name>` for the orbitdb logstore. The main reason to keep threads separated by spaces is so that a dapp that only have permissions to space `A` should not be able to post in threads created in space `B`.
 
 ## API
 
-**List threads the user is subscribed to:**
+All of the calls below assume that you have opened a space, for example:
 ```js
-const threadNames = box.threads.list()
+const space = box.openSpace('aGoodSpace')
+```
+
+**Join a thread:**
+To join a thread simply call the `joinThread` method with the name of the thread to join.
+```js
+const thread = await space.joinThread(<name>)
+```
+
+
+**Post to a thread:**
+To post in a thread the `post` method is used. It can be called with any Object. This post is appended to the end of the thread.
+By posting in a thread they automatically subscribe to it if not already subscribed.
+```js
+await thread.post(<Object>)
+```
+
+**Subscribe to a thread:**
+Saves the thread to the space with the key `"thread-<name>"`. Mostly this only needs to be called if you wish to subscribe to a thread that you have not posted to already.
+```js
+await space.subscribeThread(<name>)
+```
+
+**Read a thread:**
+This function returns an array of posts made in the thread. It's also possible to pass options to limit the number of posts or what posts are return.
+
+```js
+const posts = thread.getPosts()
+```
+
+**Watch for updates:**
+When we receive an update to the thread from the network, the provided function will get called.
+```js
+thread.onNewPost(post => {})
+```
+
+**Unsubscribe from a thread**
+Removes the thread from the list of threads that the user is subscribed to.
+```js
+await space.unsubscribeThread(<name>)
+```
+
+
+**List threads the user is subscribed to**
+Lists all threads that the user has interacted with. Returns a list of objects that contains the name of the thread and if the thread is currently open (if the orbitdb store for it is open, and we are actively listening for updates).
+
+```js
+const threadNames = space.subscribedThreads()
 console.log(threadNames)
 > ["3box-chat", "Bounties-issue432"]
 ```
 
-**Create a new thread:**
 
-The `open` parameter is a boolean that specifies if there is write permissions to the thread or not. Open threads anyone can post to, but there is no spam protection. Note that new threads are not automatically subscribed to.
 
-```js
-const thread = await box.threads.new(<name>, <open=false>)
-```
-
-**Get thread id**
-
-the thread-id is simply the orbitdb-address (String) of the underlaying DB.
+### Threads REST API
+We will also add a rest api for viewing threads when the user doesn't have a space opened. This should be as simple as
 
 ```js
-const threadId = thread.getId() 
-```
-
-**Subscribe to an existing thread:**
-
-```js
-const thread = await box.threads.subscribe(<thread-id>, <name>) 
-```
-
-**Unsubscribe from a thread:**
-
-```js
-await box.threads.unsubscribe(<name>)
-```
-
-**Posting to a thread:**
-
-```js
-await thread.post(<json-object>) 
-```
-
-**Adding a user:**
-
-```js
-await thread.addUser(<eth-addr|muport-did>) 
-```
-
-**Show users in thread:**
-
-Returns an array of `muport-did`s
-```js
-const userList = await thread.users() 
-```
-
-**Reading a thread:**
-
-We can probably design this similar to the [orbitdb feed iterator](https://github.com/orbitdb/orbit-db/blob/master/API.md#iteratoroptions-1). 
-
-```js
-const threadIterator = thread.iterator() 
-```
-
-**Watching for updates:**
-
-```js
-thread.onPost(post => {})
+const threadData = await Box.getThread(<space-name>, <thread-name>)
 ```


### PR DESCRIPTION
This updates the threads spec to be much simpler for the first iteration. Basically we only allow append only threads without any moderation.