### PR TITLE
adding link to 3IP README after commit 05dea7f

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ➡️ Have you integrated 3Box? [Add your project to 3Box Dapp Universe](./community/projects.md)
 
-📜 Want to propose an improvement? [Create a 3IP](./3IPs/3ip-0.md)
+📜 Want to propose an improvement? [Create a 3IP](./3IPs/README.md)
 
 <br>
 


### PR DESCRIPTION
Name of 3IP markdown file reflected on main README. Name was changed from 3ip-0.md to README.md