### PR TITLE
Change type of contract links

### DIFF
--- a/3IPs/3ip-5.md
+++ b/3IPs/3ip-5.md
@@ -45,7 +45,7 @@ ERC 1271 defines a method `isValidSignature` which takes two arguments `_data` a
 ```js
 {
   version: 1,
-  type: 'ethereum-contract'
+  type: 'erc1271'
   chainId: <the ID of the EVM based chain>,
   address: <the hex address of the contract>,
   message: <the message that is being signed (should contain the users DID, and the timestamp)>,


### PR DESCRIPTION
This PR Changes `ethereum-contract` to `erc1271` in 3ip-5

cc @jsidorenko